### PR TITLE
get fontconfig build working

### DIFF
--- a/5034
+++ b/5034
@@ -45,6 +45,7 @@ libXpm-3.5.12
 graphite2-1.3.13
 
 #HACK: rebuilding freetype twice is insane but necessary
+fribidi-1.0.12
 freetype-2.10.0
 harfbuzz-2.3.1
 freetype-2.10.0

--- a/build.sh
+++ b/build.sh
@@ -428,6 +428,7 @@ xxrun make install
 # ----------------------------------------------------------------------------
 fontconfig-*)
 cd $WRKDIR/$PACK
+
 save_configure_help
 
 #dll suffix hack

--- a/sources.list
+++ b/sources.list
@@ -377,6 +377,7 @@ https://dist.libuv.org/dist/v1.28.0/libuv-v1.28.0.tar.gz
 
 # http://fribidi.org
 http://fribidi.org/download/fribidi-0.19.7.tar.bz2
+https://github.com/fribidi/fribidi/releases/download/v1.0.12/fribidi-1.0.12.tar.xz
 
 # https://ftp.pcre.org/pub/pcre/
 https://ftp.pcre.org/pub/pcre/pcre-8.40.tar.gz


### PR DESCRIPTION
build fribidi 1.0.12
install msys packages for gettext-devel and gperf 

The second step should probably be in the main spbuild repo but is useful here as it saves rerunning the spbuild setup if already in a shell running the builds.  

Updates #7
