### PR TITLE
Reuse existing build artefacts where available

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -157,7 +157,9 @@ if [ ! -e "$1" ] ; then
 else
   # parameter 1: pkg-list filename
   export PKGLISTNAME=$1
-  PKGLIST=`grep -v -e "^#" -e "^\s*$" "$1" 2>/dev/null`
+#  PKGLIST=`grep -v -e "^#" -e "^\s*$" "$1" 2>/dev/null`
+  PKGLIST=`perl process_build_artefacts.pl "$1" "$2"`
+
   # parameter 2: dllsuffix
   if [ -s "$2" ] ; then
     export DLLSUFFIX=

--- a/process_build_artefacts.pl
+++ b/process_build_artefacts.pl
@@ -1,0 +1,76 @@
+#!perl
+#
+#
+#  Re-use build artefacts from previous runs.
+#
+#  To override and force a rebuild, append "rebuild" to the entry in the source list.  
+#  e.g. to rebuild readline  you might use this (without the leading # on each line):
+#
+#  ###### termcap + readline vybuildit co nejdrive
+#  termcap-1.3.1
+#  readline-8.2 rebuild
+
+
+use strict;
+use warnings;
+use 5.010;
+
+use Archive::Zip qw /:ERROR_CODES/;
+
+
+my $sources_file = shift @ARGV or die "Need sources file";
+my $suffix       = shift @ARGV || '__';
+my $bitness      = $suffix eq '_' ? '32' : '64';
+die "bitness argument $bitness is invalid, can only be 64 or 32"
+  if not $bitness eq '64' and $bitness eq '32';
+my $build_dir    = "_${sources_file}" . ($bitness eq 64 ? "__" : "_");
+my $zip_dir = '_out';
+my $zip_pfx = "${bitness}bit_";
+
+open my $sources_fh, '<', $sources_file
+  or die "Cannot open $sources_file, $!";
+
+
+
+
+my @to_build;
+my @packaged;
+
+foreach my $line (<$sources_fh>) {
+  chomp $line;
+  $line =~ s/\s+$//;
+  next if !length $line; 
+  next if $line =~ /^#/;
+  my ($package, $rebuild) = split /\s+/, $line;
+  #  only need those flagged as rebuilds
+  if (!$rebuild) {
+    push @packaged, $package;
+  } 
+  push @to_build, $package; #  we refilter lower down as there might not be a zip
+}
+
+#say 'To build: ' . join " ", @to_build;
+#say 'Packaged: ' . join " ", @packaged;
+
+if (@packaged) {
+  my @package_zips = sort glob "$zip_dir/*.zip"; 
+  foreach my $pkg (@packaged) {
+    #say STDERR "PACKAGE IS $pkg";
+    #say STDERR "$zip_dir/$zip_pfx$pkg";
+    my @targets = grep {m|^$zip_dir/$zip_pfx$pkg|} @package_zips;
+    
+    next if !@targets; #  we found a zipped package
+    
+    @to_build = grep {!m/^$pkg$/} @to_build;
+    
+    my $target = pop @targets;
+    say STDERR "Will extract $target to $build_dir";
+    my $zip = Archive::Zip->new();
+    my $status = $zip->read($target);
+    die "Read of $target failed" if $status != AZ_OK;
+    $zip->extractTree( 'c', $build_dir );
+  }
+}
+
+#  This gets ingested by the build script
+say join "\n", @to_build;

--- a/process_build_artefacts.pl
+++ b/process_build_artefacts.pl
@@ -59,9 +59,9 @@ if (@packaged) {
     #say STDERR "$zip_dir/$zip_pfx$pkg";
     my @targets = grep {m|^$zip_dir/$zip_pfx$pkg|} @package_zips;
     
-    next if !@targets; #  we found a zipped package
+    next if !@targets; #  we found no zipped package
     
-    @to_build = grep {!m/^$pkg$/} @to_build;
+    @to_build = grep {!m/^$pkg$/} @to_build;  #  retain the file order
     
     my $target = pop @targets;
     say STDERR "Will extract $target to $build_dir";

--- a/process_build_artefacts.pl
+++ b/process_build_artefacts.pl
@@ -3,7 +3,10 @@
 #
 #  Re-use build artefacts from previous runs.
 #
-#  To override and force a rebuild, append "rebuild" to the entry in the source list.  
+#  To force a rebuild of all packages set an env var called REBUILD_ALL to a true value.  
+#
+#  To override and force a rebuild for an individual package, 
+#  append "rebuild" to the entry in the source list.  
 #  e.g. to rebuild readline  you might use this (without the leading # on each line):
 #
 #  ###### termcap + readline vybuildit co nejdrive
@@ -52,7 +55,7 @@ foreach my $line (<$sources_fh>) {
 #say 'To build: ' . join " ", @to_build;
 #say 'Packaged: ' . join " ", @packaged;
 
-if (@packaged) {
+if (@packaged and !$ENV{REBUILD_ALL}) {
   my @package_zips = sort glob "$zip_dir/*.zip"; 
   foreach my $pkg (@packaged) {
     #say STDERR "PACKAGE IS $pkg";


### PR DESCRIPTION
This will save substantial development time as long-running build processes can avoid rebuilding dependencies.

