### PR TITLE
Update freeglut to 3.4.0

### DIFF
--- a/5034
+++ b/5034
@@ -36,7 +36,7 @@ postgresql-11.3
 #mysql-connector-c-6.1.10-src
 
 ###### graphics
-freeglut-3.0.0
+freeglut-3.4.0
 giflib-5.1.9
 jpeg-9c
 tiff-4.0.10

--- a/build.sh
+++ b/build.sh
@@ -1373,12 +1373,14 @@ cd $WRKDIR/$PACK
 echo "IF (FREEGLUT_BUILD_SHARED_LIBS)" >> CMakeLists.txt
 echo "SET_TARGET_PROPERTIES (freeglut PROPERTIES SUFFIX $DLLSUFFIX.dll)">> CMakeLists.txt
 echo "ENDIF ()" >> CMakeLists.txt
-xxrun cmake -G 'MSYS Makefiles' -DCMAKE_INSTALL_PREFIX=$OUT -DFREEGLUT_BUILD_SHARED_LIBS=ON -DFREEGLUT_BUILD_STATIC_LIBS=OFF
+mkdir _build
+cd _build
+xxrun cmake -G 'MSYS Makefiles' -DCMAKE_INSTALL_PREFIX=$OUT -DFREEGLUT_BUILD_SHARED_LIBS=ON -DFREEGLUT_BUILD_STATIC_LIBS=OFF ..
 xxrun make
 xxrun make install
 #HACK: OpenGL wants lib/libglut.a not lib/libfreeglut.a
 mv $OUT/lib/libfreeglut.dll.a $OUT/lib/libglut.a
-sed -i 's/-lfreeglut/-lglut/' $OUT/lib/lib/pkgconfig/freeglut.pc
+sed -i 's/-lfreeglut/-lglut/' $OUT/lib/pkgconfig/freeglut.pc
 ;;
 
 giflib-*)

--- a/patches/freeglut-3.4.0/003-freeglut-3.2.1-install-glut-h.patch
+++ b/patches/freeglut-3.4.0/003-freeglut-3.2.1-install-glut-h.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt	2019-09-25 23:43:34.000000000 +0300
++++ b/CMakeLists.txt	2019-09-30 21:10:08.047600000 +0300
+@@ -67,16 +67,12 @@
+ 
+ 
+ SET(FREEGLUT_HEADERS
++    include/GL/glut.h
+     include/GL/freeglut.h
+     include/GL/freeglut_ucall.h
+     include/GL/freeglut_ext.h
+     include/GL/freeglut_std.h
+ )
+-IF(FREEGLUT_REPLACE_GLUT)
+-    LIST(APPEND FREEGLUT_HEADERS
+-        include/GL/glut.h
+-    )
+-ENDIF()
+ SET(FREEGLUT_SRCS
+     ${FREEGLUT_HEADERS}
+     src/fg_callbacks.c

--- a/patches/freeglut-3.4.0/004-pkg-config.patch
+++ b/patches/freeglut-3.4.0/004-pkg-config.patch
@@ -1,0 +1,21 @@
+diff -urN freeglut-3.2.2/CMakeLists.txt.orig freeglut-3.2.2/CMakeLists.txt
+--- freeglut-3.2.2/CMakeLists.txt.orig	2022-06-13 18:12:10.541795000 +0200
++++ freeglut-3.2.2/CMakeLists.txt	2022-06-13 18:14:07.680099200 +0200
+@@ -607,7 +607,7 @@
+   SET(PC_CFLAGS "-DFREEGLUT_GLES")
+ ENDIF()
+ IF(FREEGLUT_BUILD_STATIC_LIBS)
+-  LIST(APPEND PC_CFLAGS -DFREEGLUT_STATIC)
++  LIST(APPEND PC_CFLAGS_PRIVATE -DFREEGLUT_STATIC)
+ ENDIF()
+ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/freeglut.pc.in ${CMAKE_BINARY_DIR}/freeglut.pc @ONLY)
+ INSTALL(FILES ${CMAKE_BINARY_DIR}/freeglut.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ RENAME ${PC_FILENAME} COMPONENT Devel)
+
+diff -urN freeglut-3.2.2/freeglut.pc.in.orig freeglut-3.2.2/freeglut.pc.in
+--- freeglut-3.2.2/freeglut.pc.in.orig	2015-02-18 01:37:05.000000000 +0100
++++ freeglut-3.2.2/freeglut.pc.in	2022-06-13 18:14:24.996997800 +0200
+@@ -8,3 +8,4 @@
+ Libs: -L${libdir} -l@PC_LIBNAME@
+ Libs.private: @PC_LIBS_PRIVATE@
+ Cflags: -I${includedir} @PC_CFLAGS@
++Cflags.private: @PC_CFLAGS_PRIVATE@

--- a/sources.list
+++ b/sources.list
@@ -222,6 +222,7 @@ https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
 #URL http://sourceforge.net/projects/freeglut/files/freeglut/
 http://downloads.sourceforge.net/freeglut/freeglut-2.8.1.tar.gz
 http://downloads.sourceforge.net/freeglut/freeglut-3.0.0.tar.gz
+http://downloads.sourceforge.net/freeglut/freeglut-3.4.0.tar.gz
 
 #### xz
 #URL http://tukaani.org/xz/


### PR DESCRIPTION
Includes two MSYS2 patches from https://github.com/msys2/MINGW-packages/tree/0c8da415d1531ccef1530931b867a4c2a5cbf1de/mingw-w64-freeglut

Updates #15 