### PR TITLE
Update libhdf5 to 1.12.2

### DIFF
--- a/5034
+++ b/5034
@@ -95,7 +95,7 @@ plplot-5.14.0
 #TEST:
 szip-2.1.1
 hdf-4.2.14
-hdf5-1.10.5
+hdf5-1.12.2
 netcdf-c-4.6.3
 
 #NOT-NEEDED: libcaca-0.99.beta19

--- a/patches/hdf5-1.12.2/hdf5-fix-find-szip.patch
+++ b/patches/hdf5-1.12.2/hdf5-fix-find-szip.patch
@@ -1,0 +1,28 @@
+--- a/CMakeFilters.cmake
++++ b/CMakeFilters.cmake
+@@ -63,9 +63,9 @@
+       find_package (ZLIB NAMES ${ZLIB_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
+       if (NOT ZLIB_FOUND)
+         find_package (ZLIB) # Legacy find
+-        if (ZLIB_FOUND)
+-          set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
+-        endif ()
++      endif ()
++      if (ZLIB_FOUND)
++        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
+       endif ()
+     endif ()
+     if (ZLIB_FOUND)
+@@ -124,9 +124,9 @@
+       find_package (SZIP NAMES ${SZIP_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
+       if (NOT SZIP_FOUND)
+         find_package (SZIP) # Legacy find
+-        if (SZIP_FOUND)
+-          set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
+-        endif ()
++      endif ()
++      if (SZIP_FOUND)
++        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
+       endif ()
+     endif ()
+   endif ()

--- a/patches/hdf5-1.12.2/hdf5-proper-library-names-mingw.patch
+++ b/patches/hdf5-1.12.2/hdf5-proper-library-names-mingw.patch
@@ -1,0 +1,20 @@
+--- hdf5-1.12.0/config/cmake_ext_mod/HDFMacros.cmake.orig	2020-04-26 10:08:44.715403300 +0300
++++ hdf5-1.12.0/config/cmake_ext_mod/HDFMacros.cmake	2020-04-26 10:34:09.889478600 +0300
+@@ -125,6 +130,8 @@
+       OUTPUT_NAME_RELEASE        ${LIB_RELEASE_NAME}
+       OUTPUT_NAME_MINSIZEREL     ${LIB_RELEASE_NAME}
+       OUTPUT_NAME_RELWITHDEBINFO ${LIB_RELEASE_NAME}
++      RUNTIME_OUTPUT_NAME        ${LIB_RELEASE_NAME}-0
++      ARCHIVE_OUTPUT_NAME        ${LIB_RELEASE_NAME}
+   )
+   #get_property (target_name TARGET ${libtarget} PROPERTY OUTPUT_NAME)
+   #get_property (target_name_debug TARGET ${libtarget} PROPERTY OUTPUT_NAME_DEBUG)
+@@ -132,7 +139,7 @@
+   #message (STATUS "${target_name} : ${target_name_debug} : ${target_name_rwdi}")
+ 
+   if (${libtype} MATCHES "STATIC")
+-    if (WIN32)
++    if (MSVC)
+       set_target_properties (${libtarget} PROPERTIES
+           COMPILE_PDB_NAME_DEBUG          ${LIB_DEBUG_NAME}
+           COMPILE_PDB_NAME_RELEASE        ${LIB_RELEASE_NAME}

--- a/sources.list
+++ b/sources.list
@@ -307,12 +307,15 @@ http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz
 https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz
 
 #URL http://www.hdfgroup.org/HDF5/
+#  odd numbered minor versions are development releases
 http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/src/hdf5-1.8.13.tar.gz
 http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.14/src/hdf5-1.8.14.tar.gz
 http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.15-patch1/src/hdf5-1.8.15-patch1.tar.gz
 http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0/src/hdf5-1.10.0.tar.gz
 https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz
 https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.gz
+https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.2/src/hdf5-1.12.2.tar.gz
+
 
 #URL http://www.hdfgroup.org/products/hdf4/
 http://www.hdfgroup.org/ftp//HDF/prev-releases/HDF4.2.10/src/hdf-4.2.10.tar.gz


### PR DESCRIPTION
Includes two patches from
https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-hdf5

The current latest is 1.13.x but odd numbered minor versions are development versions.