### PR TITLE
Update netcdf to 4.9.0

### DIFF
--- a/5034
+++ b/5034
@@ -97,7 +97,7 @@ plplot-5.14.0
 szip-2.1.1
 hdf-4.2.15
 hdf5-1.12.2
-netcdf-c-4.6.3
+netcdf-c-4.9.0
 
 #NOT-NEEDED: libcaca-0.99.beta19
 libcerf-1.3

--- a/build.sh
+++ b/build.sh
@@ -1116,7 +1116,9 @@ sed -i 's/libnetcdf_la_LDFLAGS = /libnetcdf_la_LDFLAGS = -no-undefined /' liblib
 
 save_configure_help
 CPPFLAGS=-I$OUTINC LDFLAGS=-L$OUTLIB xxrun ./configure $HOSTBUILD --prefix=$OUT --enable-static=no --enable-shared=yes \
-                        --enable-netcdf4 --enable-hdf4 --disable-dap  --disable-dynamic-loading
+                        --enable-hdf4 --disable-dap  --disable-dynamic-loading \
+                       --disable-utilities --disable-plugins \
+                       --disable-nczarr-filters --disable-nczarr
 patch_libtool
 xxrun make
 xxrun make check

--- a/patches/netcdf-c-4.9.0/0001-no-debug-libraries.patch
+++ b/patches/netcdf-c-4.9.0/0001-no-debug-libraries.patch
@@ -1,0 +1,48 @@
+diff -urN netcdf-c-4.9.0/cmake/modules/FindZip.cmake.orig netcdf-c-4.9.0/cmake/modules/FindZip.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindZip.cmake.orig	2022-06-23 17:20:15.443959500 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindZip.cmake	2022-06-23 17:20:24.156687000 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Zip_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Zip_LIBRARIES )
+-  IF(Zip_DEBUG_LIBRARY AND Zip_RELEASE_LIBRARY)
++  IF(Zip_DEBUG_LIBRARY AND Zip_RELEASE_LIBRARY AND NOT (Zip_DEBUG_LIBRARY STREQUAL Zip_RELEASE_LIBRARY))
+     SET(Zip_LIBRARIES debug ${Zip_DEBUG_LIBRARY} optimized ${Zip_RELEASE_LIBRARY})
+   ELSEIF(Zip_DEBUG_LIBRARY)
+     SET(Zip_LIBRARIES ${Zip_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake.orig netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake.orig	2022-06-23 17:59:01.868937600 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake	2022-06-23 18:07:01.844880800 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Blosc_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Blosc_LIBRARIES )
+-  IF(Blosc_DEBUG_LIBRARY AND Blosc_RELEASE_LIBRARY)
++  IF(Blosc_DEBUG_LIBRARY AND Blosc_RELEASE_LIBRARY AND NOT (Blosc_DEBUG_LIBRARY STREQUAL Blosc_RELEASE_LIBRARY))
+     SET(Blosc_LIBRARIES debug ${Blosc_DEBUG_LIBRARY} optimized ${Blosc_RELEASE_LIBRARY})
+   ELSEIF(Blosc_DEBUG_LIBRARY)
+     SET(Blosc_LIBRARIES ${Blosc_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindZstd.cmake.orig netcdf-c-4.9.0/cmake/modules/FindZstd.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindZstd.cmake.orig	2022-06-10 23:04:15.000000000 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindZstd.cmake	2022-06-23 18:10:24.665696300 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Zstd_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Zstd_LIBRARIES )
+-  IF(Zstd_DEBUG_LIBRARY AND Zstd_RELEASE_LIBRARY)
++  IF(Zstd_DEBUG_LIBRARY AND Zstd_RELEASE_LIBRARY AND NOT (Zstd_DEBUG_LIBRARY STREQUAL Zstd_RELEASE_LIBRARY))
+     SET(Zstd_LIBRARIES debug ${Zstd_DEBUG_LIBRARY} optimized ${Zstd_RELEASE_LIBRARY})
+   ELSEIF(Zstd_DEBUG_LIBRARY)
+     SET(Zstd_LIBRARIES ${Zstd_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindBz2.cmake.orig netcdf-c-4.9.0/cmake/modules/FindBz2.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindBz2.cmake.orig	2022-06-10 23:04:15.000000000 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindBz2.cmake	2022-06-23 18:13:29.254600600 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Bz2_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Bz2_LIBRARIES )
+-  IF(Bz2_DEBUG_LIBRARY AND Bz2_RELEASE_LIBRARY)
++  IF(Bz2_DEBUG_LIBRARY AND Bz2_RELEASE_LIBRARY AND NOT (Bz2_DEBUG_LIBRARY STREQUAL Bz2_RELEASE_LIBRARY))
+     SET(Bz2_LIBRARIES debug ${Bz2_DEBUG_LIBRARY} optimized ${Bz2_RELEASE_LIBRARY})
+   ELSEIF(Bz2_DEBUG_LIBRARY)
+     SET(Bz2_LIBRARIES ${Bz2_DEBUG_LIBRARY})

--- a/patches/netcdf-c-4.9.0/0002-no-file.patch
+++ b/patches/netcdf-c-4.9.0/0002-no-file.patch
@@ -1,0 +1,12 @@
+diff -urN netcdf-c-4.9.0/libsrc/posixio.c.orig netcdf-c-4.9.0/libsrc/posixio.c
+--- netcdf-c-4.9.0/libsrc/posixio.c.orig	2022-06-23 18:56:53.650461800 +0200
++++ netcdf-c-4.9.0/libsrc/posixio.c	2022-06-23 18:57:11.850400400 +0200
+@@ -1634,7 +1634,7 @@
+ #endif
+ 	if(fd < 0)
+ 	{
+-		status = errno;
++		status = errno ? errno : ENOENT;
+ 		goto unwind_new;
+ 	}
+ 	*((int *)&nciop->fd) = fd; /* cast away const */

--- a/patches/netcdf-c-4.9.0/2460.patch
+++ b/patches/netcdf-c-4.9.0/2460.patch
@@ -1,0 +1,25 @@
+From 1975911aaed1b2869a9f44fe7ca315cc52d8d6d0 Mon Sep 17 00:00:00 2001
+From: Ward Fisher <wfisher@ucar.edu>
+Date: Mon, 11 Jul 2022 14:09:57 -0600
+Subject: [PATCH] Guard _declspec(dllexport) in support of
+ https://github.com/Unidata/netcdf-c/issues/2446
+
+---
+ libdispatch/dreg.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libdispatch/dreg.c b/libdispatch/dreg.c
+index 5bb9005a18..9e65ddcbde 100644
+--- a/libdispatch/dreg.c
++++ b/libdispatch/dreg.c
+@@ -16,7 +16,10 @@
+ #include <locale.h>
+ //#include <direct.h>
+ 
++#ifdef _WIN32
+ __declspec(dllexport)
++#endif
++
+ int
+ getmountpoint(char* keyvalue, size_t size)
+ {

--- a/sources.list
+++ b/sources.list
@@ -240,6 +240,7 @@ ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.0.tar.gz
 ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz
 ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.6.2.tar.gz
 ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.6.3.tar.gz
+ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.9.0.tar.gz
 
 
 #URL http://www.fftw.org/


### PR DESCRIPTION
Configure removes --enable-netcdf4 as it is a synonym for --enable-hdf5

The nczarr components cause build failures so are excluded in the configure step.

Includes two patches from MSYS2 and a netcdf PR.
https://github.com/msys2/MINGW-packages/blob/40f98ac68ed663351fbf856e0203a7ef5f344f5f/mingw-w64-netcdf/0001-no-debug-libraries.patch https://github.com/msys2/MINGW-packages/blob/40f98ac68ed663351fbf856e0203a7ef5f344f5f/mingw-w64-netcdf/0002-no-file.patch https://github.com/Unidata/netcdf-c/pull/2460.patch

More details in #16