### PR TITLE
Update libtiff to 4.5.0

### DIFF
--- a/5034
+++ b/5034
@@ -37,7 +37,7 @@ postgresql-15.1
 freeglut-3.4.0
 giflib-5.1.9
 jpeg-9c
-tiff-4.0.10
+tiff-4.5.0
 libpng-1.6.37
 libXpm-3.5.12
 graphite2-1.3.13

--- a/patches/tiff-4.5.0/0001-fix-test-newline.patch
+++ b/patches/tiff-4.5.0/0001-fix-test-newline.patch
@@ -1,0 +1,32 @@
+--- ./test/tiff2ps-EPS1.sh.orig	2021-03-05 14:01:43.000000000 +0100
++++ ./test/tiff2ps-EPS1.sh	2021-05-20 10:38:06.153946000 +0200
+@@ -5,4 +5,4 @@
+ PSFILE=o-tiff2ps-EPS1.ps
+ . ${srcdir:-.}/common.sh
+ f_test_stdout "${TIFF2PS} -e -1" "${IMG_MINISWHITE_1C_1B}" "${PSFILE}"
+-diff -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
++diff --strip-trailing-cr -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
+--- ./test/tiff2ps-PS1.sh.orig	2021-03-05 14:01:43.000000000 +0100
++++ ./test/tiff2ps-PS1.sh	2021-05-20 10:38:40.989191000 +0200
+@@ -6,4 +6,4 @@
+ . ${srcdir:-.}/common.sh
+ f_test_stdout "${TIFF2PS} -a -p -1" "${IMG_MINISWHITE_1C_1B}" "${PSFILE}"
+ #diff -I '%%(CreationDate|Title):.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
+-diff -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
++diff --strip-trailing-cr -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
+--- ./test/tiff2ps-PS2.sh.orig	2021-03-05 14:01:43.000000000 +0100
++++ ./test/tiff2ps-PS2.sh	2021-05-20 10:38:46.435907600 +0200
+@@ -5,4 +5,4 @@
+ PSFILE=o-tiff2ps-PS2.ps
+ . ${srcdir:-.}/common.sh
+ f_test_stdout "${TIFF2PS} -a -p -2" "${IMG_MINISWHITE_1C_1B}" "${PSFILE}"
+-diff -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
++diff --strip-trailing-cr -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
+--- ./test/tiff2ps-PS3.sh.orig	2021-03-05 14:01:43.000000000 +0100
++++ ./test/tiff2ps-PS3.sh	2021-05-20 10:38:51.687517100 +0200
+@@ -5,4 +5,4 @@
+ PSFILE=o-tiff2ps-PS3.ps
+ . ${srcdir:-.}/common.sh
+ f_test_stdout "${TIFF2PS} -a -p -3" "${IMG_MINISWHITE_1C_1B}" "${PSFILE}"
+-diff -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1
++diff --strip-trailing-cr -I '%%CreationDate:.*' -I '%%Title:.*' -u "${REFS}/${PSFILE}" "${PSFILE}" || exit 1

--- a/sources.list
+++ b/sources.list
@@ -144,6 +144,7 @@ ftp://ftp.remotesensing.org/pub/libtiff/tiff-4.0.3.tar.gz
 ftp://ftp.remotesensing.org/pub/libtiff/tiff-4.0.6.tar.gz
 ftp://download.osgeo.org/libtiff/tiff-4.0.7.tar.gz
 http://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz
+http://download.osgeo.org/libtiff/tiff-4.5.0.tar.gz
 
 #### fontconfig
 #URL http://fontconfig.org/release/


### PR DESCRIPTION
Includes a patch file adapted from MSYS2 to get the tests to pass: https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-libtiff/0001-fix-test-newline.patch

Fixes #22 