### PR TITLE
build.sh: modify args handling and default values for the dll suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ db-6.2.38
 
 #  DLL naming convention
 
-One point that is worth noting is that DLLs built using this system have a suffix appended to the name.  This is so they are less likely to clash with other versions of those DLLs that have already been loaded, and which may be incompatible.  The 64-bit builds use two underscores by default, for example ```libpong__.dll```, while the 32-bit builds use a single underscore (```libpong_.dll```).  Note that this suffix needs to be passed as an argument to the ```build.sh``` call or no suffix is appended.
+One point that is worth noting is that DLLs built using this system have a suffix appended to the name.  This is so they are less likely to clash with other versions of those DLLs that have already been loaded, and which may be incompatible.  The 64-bit builds use two underscores by default, for example ```libpong__.dll```, while the 32-bit builds use a single underscore (```libpong_.dll```).  Note that this suffix is added by default if no second argument is specified.  If you want no suffix then pass ```none``` as the second argument, for example ```./build.sh 5034 none```.
 
 The DLL suffix is probably the point of greatest complexity for the build system, especially for cmake builds.  A [patchelf](https://github.com/NixOS/patchelf) equivalent for PE32 files would  greatly simplify the whole process.  

--- a/build.sh
+++ b/build.sh
@@ -145,10 +145,13 @@ ARCHNICK=32bit
 ARCHBITS=32
 fi
 
+export DLLSUFFIX=$2
 if [ ! -e "$1" ] ; then
   echo "Warning: assuming params to be package names!"
   export PKGLISTNAME=buildtest
   PKGLIST=$@
+  #  dllsuffix will be set to the default below
+  export DLLSUFFIX=
 else
   # parameter 1: pkg-list filename
   export PKGLISTNAME=$1
@@ -158,7 +161,6 @@ fi
 
 #  handle no dllsuffix being passed
 #  assumes user wants _ or __, which is what the build system is set up for
-export DLLSUFFIX=$2
 if [ -z "$DLLSUFFIX" ] ; then
   if [ $IS64BIT ] ; then
     export DLLSUFFIX=__

--- a/build.sh
+++ b/build.sh
@@ -148,24 +148,29 @@ fi
 if [ ! -e "$1" ] ; then
   echo "Warning: assuming params to be package names!"
   export PKGLISTNAME=buildtest
-  if [ $IS64BIT ] ; then
-    export DLLSUFFIX=__
-  else
-    export DLLSUFFIX=_
-  fi
   PKGLIST=$@
 else
   # parameter 1: pkg-list filename
   export PKGLISTNAME=$1
 #  PKGLIST=`grep -v -e "^#" -e "^\s*$" "$1" 2>/dev/null`
   PKGLIST=`perl process_build_artefacts.pl "$1" "$2"`
+fi
 
-  # parameter 2: dllsuffix
-  if [ -s "$2" ] ; then
-    export DLLSUFFIX=
+#  handle no dllsuffix being passed
+#  assumes user wants _ or __, which is what the build system is set up for
+export DLLSUFFIX=$2
+if [ -z "$DLLSUFFIX" ] ; then
+  if [ $IS64BIT ] ; then
+    export DLLSUFFIX=__
   else
-    export DLLSUFFIX=$2
+    export DLLSUFFIX=_
   fi
+  echo "no dllsuffix arg, defaulting to $DLLSUFFIX"
+fi
+#  user really wants no suffix
+if [ "$DLLSUFFIX" == "none" ] ; then
+  export DLLSUFFIX=
+  echo "dllsuffix arg is 'none', defaulting to no suffix"
 fi
 
 #calling pwd needs correct PATH


### PR DESCRIPTION
This simplifies the case for job files but breaks the case where distributions are passed as command line args.  

I guess two options are to only use job files or only support one distribution as a command line arg.  I'm not sure how common it is to specify jobs on the command line but assume it is not used a lot.  

Updates #37 