### PR TITLE
Update to netcdf 4.9.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1140,16 +1140,18 @@ cd $WRKDIR/$PACK
 
 ###this is a hack
 sed -i s/-ldf/-lhdf/ configure
-sed -i 's/libnetcdf_la_LDFLAGS = /libnetcdf_la_LDFLAGS = -no-undefined /' liblib/Makefile.in
+#sed -i 's/libnetcdf_la_LDFLAGS = /libnetcdf_la_LDFLAGS = -no-undefined /' liblib/Makefile.in
 
 save_configure_help
-CPPFLAGS=-I$OUTINC LDFLAGS=-L$OUTLIB xxrun ./configure $HOSTBUILD --prefix=$OUT --enable-static=no --enable-shared=yes \
+CPPFLAGS=-I$OUTINC LDFLAGS="-L$OUTLIB -Wl,--export-all-symbols" \
+    xxrun ./configure $HOSTBUILD --prefix=$OUT --enable-static=no --enable-shared=yes \
                         --enable-hdf4 --disable-dap  --disable-dynamic-loading \
                        --disable-utilities --disable-plugins \
-                       --disable-nczarr-filters --disable-nczarr
+                       --disable-nczarr-filters --disable-nczarr \
+                       --disable-byterange
 patch_libtool
-xxrun make
-xxrun make check
+xxrun make 
+xxrun make check 
 xxrun make install
 ;;
 

--- a/patches/netcdf-c-4.9.2/0001-no-debug-libraries.patch
+++ b/patches/netcdf-c-4.9.2/0001-no-debug-libraries.patch
@@ -1,0 +1,48 @@
+diff -urN netcdf-c-4.9.0/cmake/modules/FindZip.cmake.orig netcdf-c-4.9.0/cmake/modules/FindZip.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindZip.cmake.orig	2022-06-23 17:20:15.443959500 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindZip.cmake	2022-06-23 17:20:24.156687000 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Zip_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Zip_LIBRARIES )
+-  IF(Zip_DEBUG_LIBRARY AND Zip_RELEASE_LIBRARY)
++  IF(Zip_DEBUG_LIBRARY AND Zip_RELEASE_LIBRARY AND NOT (Zip_DEBUG_LIBRARY STREQUAL Zip_RELEASE_LIBRARY))
+     SET(Zip_LIBRARIES debug ${Zip_DEBUG_LIBRARY} optimized ${Zip_RELEASE_LIBRARY})
+   ELSEIF(Zip_DEBUG_LIBRARY)
+     SET(Zip_LIBRARIES ${Zip_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake.orig netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake.orig	2022-06-23 17:59:01.868937600 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindBlosc.cmake	2022-06-23 18:07:01.844880800 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Blosc_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Blosc_LIBRARIES )
+-  IF(Blosc_DEBUG_LIBRARY AND Blosc_RELEASE_LIBRARY)
++  IF(Blosc_DEBUG_LIBRARY AND Blosc_RELEASE_LIBRARY AND NOT (Blosc_DEBUG_LIBRARY STREQUAL Blosc_RELEASE_LIBRARY))
+     SET(Blosc_LIBRARIES debug ${Blosc_DEBUG_LIBRARY} optimized ${Blosc_RELEASE_LIBRARY})
+   ELSEIF(Blosc_DEBUG_LIBRARY)
+     SET(Blosc_LIBRARIES ${Blosc_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindZstd.cmake.orig netcdf-c-4.9.0/cmake/modules/FindZstd.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindZstd.cmake.orig	2022-06-10 23:04:15.000000000 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindZstd.cmake	2022-06-23 18:10:24.665696300 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Zstd_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Zstd_LIBRARIES )
+-  IF(Zstd_DEBUG_LIBRARY AND Zstd_RELEASE_LIBRARY)
++  IF(Zstd_DEBUG_LIBRARY AND Zstd_RELEASE_LIBRARY AND NOT (Zstd_DEBUG_LIBRARY STREQUAL Zstd_RELEASE_LIBRARY))
+     SET(Zstd_LIBRARIES debug ${Zstd_DEBUG_LIBRARY} optimized ${Zstd_RELEASE_LIBRARY})
+   ELSEIF(Zstd_DEBUG_LIBRARY)
+     SET(Zstd_LIBRARIES ${Zstd_DEBUG_LIBRARY})
+diff -urN netcdf-c-4.9.0/cmake/modules/FindBz2.cmake.orig netcdf-c-4.9.0/cmake/modules/FindBz2.cmake
+--- netcdf-c-4.9.0/cmake/modules/FindBz2.cmake.orig	2022-06-10 23:04:15.000000000 +0200
++++ netcdf-c-4.9.0/cmake/modules/FindBz2.cmake	2022-06-23 18:13:29.254600600 +0200
+@@ -39,7 +39,7 @@
+                PATHS ${Bz2_LIBRARY_DIRS} NO_DEFAULT_PATH)
+ 
+   SET(Bz2_LIBRARIES )
+-  IF(Bz2_DEBUG_LIBRARY AND Bz2_RELEASE_LIBRARY)
++  IF(Bz2_DEBUG_LIBRARY AND Bz2_RELEASE_LIBRARY AND NOT (Bz2_DEBUG_LIBRARY STREQUAL Bz2_RELEASE_LIBRARY))
+     SET(Bz2_LIBRARIES debug ${Bz2_DEBUG_LIBRARY} optimized ${Bz2_RELEASE_LIBRARY})
+   ELSEIF(Bz2_DEBUG_LIBRARY)
+     SET(Bz2_LIBRARIES ${Bz2_DEBUG_LIBRARY})


### PR DESCRIPTION
And associated compiler settings so it works with gcc 11, 12 and 13.

The patch affects only the cmake files so is probably not needed since compilation uses autotools.  
It is otherwise harmless.  

Fixes #42