### PR TITLE
Move gsl-config.bat quoting to right place

### DIFF
--- a/patches/gsl-2.6/gsl-config.bat.win-gcc
+++ b/patches/gsl-2.6/gsl-config.bat.win-gcc
@@ -1,12 +1,11 @@
 @echo off
 rem simplified replacement for the original shell script
-set ROOT="%~dp0"
 
-set XCFLAGS=-I%ROOT%..\include
-set XLIBS1=-L%ROOT%..\lib -lgsl -lgslcblas
-set XLIBS2=-L%ROOT%..\lib -lgsl
+set XCFLAGS="-I%~dp0%..\include"
+set XLIBS1="-L%~dp0%..\lib" -lgsl -lgslcblas
+set XLIBS2="-L%~dp0%..\lib" -lgsl
 set XVERSION=2.6
-set XPREFIX=%ROOT%..\
+set XPREFIX="%~dp0%..\"
 
 for %%p in (%*) do (
   if x%%p == x--cflags     echo %XCFLAGS%

--- a/patches/gsl-2.6/gsl-config.bat.win-gcc
+++ b/patches/gsl-2.6/gsl-config.bat.win-gcc
@@ -1,10 +1,10 @@
 @echo off
 rem simplified replacement for the original shell script
-set ROOT=%~dp0
+set ROOT="%~dp0"
 
-set XCFLAGS=-I"%ROOT%..\include"
-set XLIBS1=-L"%ROOT%..\lib" -lgsl -lgslcblas
-set XLIBS2=-L"%ROOT%..\lib" -lgsl
+set XCFLAGS=-I%ROOT%..\include
+set XLIBS1=-L%ROOT%..\lib -lgsl -lgslcblas
+set XLIBS2=-L%ROOT%..\lib -lgsl
 set XVERSION=2.6
 set XPREFIX=%ROOT%..\
 


### PR DESCRIPTION
Without this, it fails in "Perl in space" with the error:

```
(BIT AFTER THE SPACE IN FULL PATH)straw-actual\c\bin\..\ was unexpected at this time.
```

Also, this PR is against the 2.6 script, though there's now a 2.7 - is there a plan to update for that?